### PR TITLE
Update libraries

### DIFF
--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -22,10 +22,10 @@ Dependencies
 Libraries you need to download separately and build:
 
                 default path               download
-OpenSSL         \openssl-1.0.1c-mgw        http://www.openssl.org/source/
+OpenSSL         \openssl-1.0.1j-mgw        http://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
-Boost           \boost-1.50.0-mgw          http://www.boost.org/users/download/
-miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
+Boost           \boost-1.55.0-mgw          http://www.boost.org/users/download/
+miniupnpc       \miniupnpc-1.9-mgw         http://miniupnp.tuxfamily.org/files/
 
 Their licenses:
 
@@ -36,10 +36,10 @@ Their licenses:
 
 Versions used in this release:
 
-	OpenSSL      1.0.1c
+	OpenSSL      1.0.1j
 	Berkeley DB  4.8.30.NC
-	Boost        1.50.0
-	miniupnpc    1.6
+	Boost        1.55.0
+	miniupnpc    1.9
 
 
 OpenSSL
@@ -49,7 +49,7 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-	cd /c/openssl-1.0.1c-mgw
+	cd /c/openssl-1.0.1j-mgw
 	./config
 	make
 
@@ -66,7 +66,7 @@ Boost
 MSYS shell:
 
 	downloaded boost jam 3.1.18
-	cd \boost-1.50.0-mgw
+	cd \boost-1.55.0-mgw
 	bjam toolset=gcc --build-type=complete stage
 
 MiniUPnPc
@@ -75,15 +75,15 @@ UPnP support is optional, make with `USE_UPNP=` to disable it.
 
 MSYS shell:
 
-	cd /c/miniupnpc-1.6-mgw
+	cd /c/miniupnpc-1.9-mgw
 	make -f Makefile.mingw
 	mkdir miniupnpc
 	cp *.h miniupnpc/
 
-Litecoin
+Mooncoin
 -------
 MSYS shell:
 
-	cd \litecoin\src
+	cd \mooncoin\src
 	mingw32-make -f makefile.mingw
-	strip litecoind.exe
+	strip mooncoind.exe

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -102,7 +102,7 @@ Note: After you have installed the dependencies, you should check that the Brew 
 
         openssl version
 
-into Terminal. You should see OpenSSL 1.0.1e 11 Feb 2013.
+into Terminal. You should see OpenSSL 1.0.1j 15 Oct 2014.
 
 If not, you can ensure that the Brew OpenSSL is correctly linked by running
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -46,10 +46,10 @@ Licenses of statically linked libraries:
 
 - Versions used in this release:
 -  GCC           4.3.3
--  OpenSSL       1.0.1c
+-  OpenSSL       1.0.1j
 -  Berkeley DB   4.8.30.NC
--  Boost         1.37
--  miniupnpc     1.6
+-  Boost         1.55
+-  miniupnpc     1.9
 
 Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
@@ -71,8 +71,8 @@ for other Ubuntu & Debian:
 
 	sudo apt-get install libdb4.8-dev
 	sudo apt-get install libdb4.8++-dev
-	sudo apt-get install libboost1.37-dev
- (If using Boost 1.37, append -mt to the boost libraries in the makefile)
+	sudo apt-get install libboost1.55-dev
+ (If using Boost 1.55, append -mt to the boost libraries in the makefile)
 
 Optional:
 
@@ -81,14 +81,14 @@ Optional:
 
 Notes
 -----
-The release is built with GCC and then "strip bitcoind" to strip the debug
+The release is built with GCC and then "strip mooncoind" to strip the debug
 symbols, which reduces the executable size by about 90%.
 
 
 miniupnpc
 ---------
-	tar -xzvf miniupnpc-1.6.tar.gz
-	cd miniupnpc-1.6
+	tar -xzvf miniupnpc-1.9.tar.gz
+	cd miniupnpc-1.9
 	make
 	sudo su
 	make install

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -34,7 +34,7 @@ Release Process
 
 	mkdir -p inputs; cd inputs/
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.20140401.tar.gz' -O miniupnpc-1.9.20140401.tar.gz'
-	wget 'http://www.openssl.org/source/openssl-1.0.1g.tar.gz'
+	wget 'http://www.openssl.org/source/openssl-1.0.1j.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/history/libpng16/libpng-1.6.8.tar.gz'

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1127,12 +1127,12 @@ int64 static GetBlockValue(int nHeight, int64 nFees, uint256 prevHash)
                 nSubsidy = (1 + generateMTRandom(seed, 599999)) * COIN;
         } else if(nHeight <= 300000) {
                 nSubsidy = (1 + generateMTRandom(seed, 349999)) * COIN;
-        } else if(nHeight <= 350000) {
+        } else if(nHeight <= 333332) {
                 nSubsidy = (1 + generateMTRandom(seed, 174999)) * COIN;
         } else if(nHeight <= 375000) {
-                nSubsidy = (1 + generateMTRandom(seed, 99999)) * COIN;
+                nSubsidy = 50000;
         } else if(nHeight <= 384400) {
-                nSubsidy = (1 + generateMTRandom(seed, 49999)) * COIN;
+                nSubsidy = 25000;
         }
 
 	if (nHeight % 29531 == 0) {

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -22,7 +22,7 @@ USE_UPNP:=-
 USE_IPV6:=1
 
 DEPSDIR?=/usr/local
-BOOST_SUFFIX?=-mgw46-mt-sd-1_52
+BOOST_SUFFIX?=-mgw48-mt-s-1_55
 
 INCLUDEPATHS= \
  -I"$(CURDIR)" \


### PR DESCRIPTION
Use new openssl version 1.0.1j (heartbleed bug eliminated) !
Keep Berkeley DB 4.8.30. Do NOT update to newer version, because your wallet.dat would not be compatible.
Boost updated from version 1.50 to version 1.55
miniupnpc updated from version 1.6 to 1.9
